### PR TITLE
🔧 Provide the codecov token from secrets

### DIFF
--- a/.github/workflows/MergeToMain.yml
+++ b/.github/workflows/MergeToMain.yml
@@ -75,6 +75,6 @@ jobs:
       - name: Code coverage
         uses: codecov/codecov-action@v3
         with:
-          token: "${{ secrets.CODECOV_TOKEN }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./.codecoverage"
           fail_ci_if_error: true

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Code coverage
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./.codecoverage"
           fail_ci_if_error: true
 


### PR DESCRIPTION
Looks like we need to always provide the CodeCov token